### PR TITLE
Make Causeway compatible with Clojure >= 1.7.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject causeway "0.4.4"
+(defproject causeway "0.4.5"
   :description "Simple library for rapid web development with Clojure"
   :url "https://github.com/cosmi/causeway"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [sass "3.2.6"]
                  [digest "1.3.0"]
                  [ring "1.2.0"]
@@ -13,7 +13,7 @@
                  [clj-time "0.5.1"]
                  [org.marianoguerra/clj-rhino "0.2.1"]
                  [com.novemberain/monger "1.6.0"]
-                 [instaparse "1.2.7"]
+                 [instaparse "1.4.9"]
                  [org.clojure/core.match "0.2.0-rc5"]
                  [com.taoensso/timbre "2.6.1"] 
                  [ro.isdc.wro4j/wro4j-extensions "1.7.0"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/cosmi/causeway"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [sass "3.2.6"]
                  [digest "1.3.0"]
                  [ring "1.2.0"]


### PR DESCRIPTION
Clojure 1.7 introduced function `cat` which collided with `instaparse` lib. It was fixed in its `1.3.4` version.

I have upgraded dependency of both Clojure and instaparse, tested with `lein new causeway project-name` and it seems to work.

`lein test` seems to have some problems in current version so I wasn't able to confirm via tests that this pull request doesn't introduce any breaking changes. I hope it works.